### PR TITLE
remove non-standard include

### DIFF
--- a/ml_multout.c
+++ b/ml_multout.c
@@ -40,7 +40,6 @@ left in are prefixed by "#"s (this excludes function seperators)
 /* original includes */
 #include <stdio.h>    
 #include <stdlib.h>
-#include <malloc.h>
 #include <math.h>
 #include <assert.h>
 #include <memory.h>

--- a/mulcross.c
+++ b/mulcross.c
@@ -22,7 +22,6 @@
 
 #include <stdio.h>       /* magical incantations */
 #include <stdlib.h>
-#include <malloc.h>
 #include <math.h>
 #include <assert.h>
 #include <memory.h>

--- a/multout.c
+++ b/multout.c
@@ -46,7 +46,6 @@ Differences between 2.00.04 and 3.00
 
 #include <stdio.h>       /* magical incantations */
 #include <stdlib.h>
-#include <malloc.h>
 #include <math.h>
 #include <assert.h>
 #include <memory.h>


### PR DESCRIPTION
<malloc.h> header is deprecated and may fail in modern compilers or non-linux (definitely fails on MacOS).
stdlib.h should be enough