### PR TITLE
fix crash

### DIFF
--- a/mulcross.c
+++ b/mulcross.c
@@ -211,7 +211,7 @@ void Pollute()
   double *DirVect;            /* direction vector */
   int SampStart;              /* first polluted sample index */
                  
-  DirVect = malloc((VectLen+1)*sizeof(float)); ALLCHK(DirVect)               
+  DirVect = malloc((VectLen+1)*sizeof(double)); ALLCHK(DirVect)               
   PollDist = NumUnits * sqrt(Chi2_At_Pt001(VectLen) / VectLen);
   SampStart = XCnt - PollCnt + 1;
   for (Samp = SampStart; Samp <=XCnt; Samp++) {


### PR DESCRIPTION
https://stackoverflow.com/questions/40375207/mulcross-data-generator-runs-wrongly-freeinvalid-next-size